### PR TITLE
Changes hashlib.md5 call that can throw exception to hashlib.new, which doesn't

### DIFF
--- a/spodcast/spodcast.py
+++ b/spodcast/spodcast.py
@@ -58,7 +58,7 @@ class Spodcast:
         cred_directory = Config.get_config_dir()
         if os.path.isdir(cred_directory):
             (username,password) = line.split()
-            cred_filename = CREDENTIALS_PREFIX + "-" + hashlib.md5(username.encode('utf-8'),usedforsecurity=False).hexdigest() + ".json"
+            cred_filename = CREDENTIALS_PREFIX + "-" + hashlib.new('md5', username.encode('utf-8'), usedforsecurity=False).hexdigest() + ".json"
             cred_location = os.path.join(cred_directory, cred_filename)
             conf = Session.Configuration.Builder().set_stored_credential_file(cred_location).build()
             session = Session.Builder(conf).user_pass(username, password).create()


### PR DESCRIPTION
`hashlib.md5` can throw an exception when used with the `usedforsecurity` keyword argument if the underlying C library doesn't support the keyword. This pull request changes the call that creates the credentials file to use `hashlib.new`, which won't throw an exception.